### PR TITLE
Layer pybindings

### DIFF
--- a/configure
+++ b/configure
@@ -445,6 +445,7 @@ OBJECTS = $(patsubst src/%.cpp,build/%.o,$(SOURCES))
 EXAMPLES := examples/Single_energy/single_energy \
             examples/Multiple_energy/multiple_energy \
             examples/Atm_default/atm_default \
+            examples/explicit_layers/explicit_layers \
             examples/Bodies/bodies \
             examples/Xsections/xsections \
             examples/NSI/nsi \
@@ -525,6 +526,10 @@ examples/HDF5_Write_Read/read : $(DYN_PRODUCT) examples/HDF5_Write_Read/read.cpp
 examples/Atm_default/atm_default : $(DYN_PRODUCT) examples/Atm_default/main.cpp
 	@echo Compiling atmospheric example
 	@$(CXX) $(EXAMPLES_FLAGS) examples/Atm_default/main.cpp -lnuSQuIDS $(LDFLAGS) -o $@
+
+examples/explicit_layers/explicit_layers : $(DYN_PRODUCT) examples/explicit_layers/main.cpp
+	@echo Compiling explicit layers example
+	$(CXX) $(EXAMPLES_FLAGS) examples/explicit_layers/main.cpp -lnuSQuIDS $(LDFLAGS) -o $@
 
 build/exBody.o : examples/Bodies/exBody.h examples/Bodies/exBody.cpp
 	@$(CXX) $(EXAMPLES_FLAGS) -c examples/Bodies/exBody.cpp -o $@

--- a/examples/explicit_layers/main.cpp
+++ b/examples/explicit_layers/main.cpp
@@ -10,131 +10,80 @@ using namespace nusquids;
 int main(){
 
   squids::Const units;
-  unsigned int evalThreads = 1;
-  std::vector<nuSQUIDS> nusq_array;
+//   unsigned int evalThreads = 8;
+//   std::vector<nuSQUIDS> nusq_array;
   
   marray<double,2> lengths {8,10};
   marray<double,2> densities {8,10};
+  marray<double,2> ye {8,10};
+  marray<double,1> energies {8};
+  // These lengths and densities are completely made up nonsense.
+  // The intention is that we would have a pybinding in the real
+  // world where we pass explicit distances and densities that were
+  // calculated elsewhere.
   for (int i = 0; i < lengths.extent(0); i++){
     for (int j = 1; j < lengths.extent(1) + 1; j++){
       lengths[i][j-1] = 5000./j * units.km;
       densities[i][j-1] = (13. + i)/j;
+      ye[i][j-1] = 0.5;
     }
+    energies[i] = 10.*units.GeV;
   }
-  std::vector< std::vector< std::shared_ptr<ConstantDensity>>> const_dens_array;
-  std::vector< std::vector< std::shared_ptr<ConstantDensity::Track>>> const_dens_track_array;
   
-  for (int i = 0; i < lengths.extent(0); i++){
-    std::vector< std::shared_ptr<ConstantDensity>> vdens;
-    std::vector< std::shared_ptr<ConstantDensity::Track>> vtrk;
-    
-    for (int j = 0; j < lengths.extent(1); j++){
-      vdens.push_back(std::make_shared<ConstantDensity>(densities[i][j], 0.5));
-      vtrk.push_back(std::make_shared<ConstantDensity::Track>(lengths[i][j]));
-    }
-    const_dens_array.push_back(vdens);
-    const_dens_track_array.push_back(vtrk);
-  }
+  std::cout << "Begin: constructing nuSQuIDS-Layers object" << std::endl;
+  nuSQUIDSLayers<> nus_layer(lengths, densities, ye, energies, 3, neutrino);
+  std::cout << "End: constructing nuSQuIDS-Layers object" << std::endl;
+  
+  nus_layer.Set_MixingParametersToDefault();
+  nus_layer.Set_AllowConstantDensityOscillationOnlyEvolution(false);
   
   marray<double,1> ini_state({3},{0,1,0});
-  // construct nusquids objects
-  for (int i = 0; i < lengths.extent(0); i++){
-    nusq_array.emplace_back(3, neutrino);
-    nusq_array.back().Set_E(10.*units.GeV);
-    // set body and track to the first layer of the array of layers 
-    // corresponding to this particular nusquids object.
-    nusq_array.back().Set_Body(const_dens_array[i][0]);
-    nusq_array.back().Set_Track(const_dens_track_array[i][0]);
-    nusq_array.back().Set_MixingParametersToDefault();
-    nusq_array.back().Set_AllowConstantDensityOscillationOnlyEvolution(true);
-    nusq_array.back().Set_initial_state(ini_state, flavor);
+  nus_layer.Set_initial_state(ini_state, flavor);
+  
+  marray<double,2> states;
+  
+  std::cout << "Initial interaction picture states:" << std::endl;
+  states = nus_layer.GetStatesArr();
+  for (int i=0; i<states.extent(0); i++){
+   for (int j=0; j<states.extent(1); j++)
+     std::cout << states[i][j] << "   ";
+   std::cout << std::endl;
   }
-
-  std::cout << "Ini state in nus objects:" << std::endl;
+  
+  std::cout << "Initial flavor state:" << std::endl;
   for (int n = 0; n < lengths.extent(0); n ++){
     std::cout << n << ": ";
     for(int i = 0; i < 3; i++){
-      std::cout << nusq_array[n].EvalFlavor(i) << " ";
+      std::cout << nus_layer.EvalFlavorAtNode(i, n) << " ";
     }
     std::cout << std::endl;
   }
-
+  
+  nus_layer.Set_EvalThreads(1);
+  
   auto start = std::chrono::high_resolution_clock::now();
   
-  if(evalThreads==1){
-    std::cout << "using single task mode" << std::endl;
-    for (int n = 0; n < lengths.extent(0); n++){
-      std::cout << "evolving nusq object " << n << std::endl;
-      for (int i = 0; i < lengths.extent(1); i++){
-        nusq_array[n].Set_Body(const_dens_array[n][i]);
-        nusq_array[n].Set_Track(const_dens_track_array[n][i]);
-        nusq_array[n].EvolveState();
-        //for(int j = 0; j < 3; j++){
-        //  std::cout << nusq_array[n].EvalFlavor(j) << " ";
-        //}
-        //std::cout << std::endl;
-      }
-    }
-  }
-  else{
-    std::cout << "using " << evalThreads << " threads" << std::endl;
-    for (int i = 0; i < lengths.extent(1); i++){
-      ThreadPool tpool(evalThreads);
-      std::vector<std::future<void>> tasks;
-      tasks.reserve(nusq_array.size());
-      std::cout << "working on layer " << i << std::endl;
-      for(int n = 0; n < nusq_array.size(); n++){
-        nusq_array[n].Set_Body(const_dens_array[n][i]);
-        nusq_array[n].Set_Track(const_dens_track_array[n][i]);
-      }
-      for(nuSQUIDS& nsq : nusq_array)
-         tasks.emplace_back(tpool.enqueue([&](){ nsq.EvolveState(); }));
-      for(const auto& task : tasks){
-        task.wait();
-      }
-    }
-    ////////////////////
-    // It would probably be more efficient if every thread could do the entire 
-    // evolution through all layers, rather than waiting for each layer to finish
-    // in all nuSQuIDS calculators. I was trying to do it below, but it doesn't work...
-    // If you have better C++ skills than me, you can probably make it work. 
-    //
-    // std::cout << "using " << evalThreads << " threads" << std::endl;
-    // ThreadPool tpool(evalThreads);
-    // std::vector<std::future<void>> tasks;
-    // tasks.reserve(nusq_array.size());
-    // 
-    // for(int n = 0; n < nusq_array.size(); n++){
-    //   nuSQUIDS& nus = nusq_array[n];
-    //   std::vector< std::shared_ptr<ConstantDensity>> vdens = const_dens_array[n];
-    //   std::vector< std::shared_ptr<ConstantDensity::Track>> vtrk = const_dens_track_array[n];
-    //   
-    //   tasks.emplace_back(tpool.enqueue([&](){
-    //     for (int i = 0; i < vdens.size(); i++){
-    //       nus.Set_Body(vdens[i]);
-    //       nus.Set_Track(vtrk[i]);
-    //       nus.EvolveState();
-    //     }
-    //   }));
-    // }
-    // for(const auto& task : tasks){
-    //   task.wait();
-    // }
-    ///////////////////
-  }
-
+  nus_layer.EvolveState();
+  
   auto finish = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> elapsed = finish - start;
   std::cout << "evolution time: " << elapsed.count() << " s" << std::endl;
   
-  std::cout << "Final state in nus objects:" << std::endl;
+  std::cout << "Final interaction picture states:" << std::endl;
+  states = nus_layer.GetStatesArr();
+  for (int i=0; i<states.extent(0); i++){
+   for (int j=0; j<states.extent(1); j++)
+     std::cout << states[i][j] << "   ";
+   std::cout << std::endl;
+  }
+  
+  std::cout << "Final flavor state:" << std::endl;
   for (int n = 0; n < lengths.extent(0); n ++){
     std::cout << n << ": ";
     for(int i = 0; i < 3; i++){
-      std::cout << nusq_array[n].EvalFlavor(i) << " ";
+      std::cout << nus_layer.EvalFlavorAtNode(i, n) << " ";
     }
     std::cout << std::endl;
   }
-
   return 0;
 }

--- a/examples/explicit_layers/main.cpp
+++ b/examples/explicit_layers/main.cpp
@@ -1,0 +1,140 @@
+#include <nuSQuIDS/nuSQuIDS.h>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <vector>
+#include <chrono>  // for high_resolution_clock
+
+using namespace nusquids;
+
+int main(){
+
+  squids::Const units;
+  unsigned int evalThreads = 1;
+  std::vector<nuSQUIDS> nusq_array;
+  
+  marray<double,2> lengths {8,10};
+  marray<double,2> densities {8,10};
+  for (int i = 0; i < lengths.extent(0); i++){
+    for (int j = 1; j < lengths.extent(1) + 1; j++){
+      lengths[i][j-1] = 5000./j * units.km;
+      densities[i][j-1] = (13. + i)/j;
+    }
+  }
+  std::vector< std::vector< std::shared_ptr<ConstantDensity>>> const_dens_array;
+  std::vector< std::vector< std::shared_ptr<ConstantDensity::Track>>> const_dens_track_array;
+  
+  for (int i = 0; i < lengths.extent(0); i++){
+    std::vector< std::shared_ptr<ConstantDensity>> vdens;
+    std::vector< std::shared_ptr<ConstantDensity::Track>> vtrk;
+    
+    for (int j = 0; j < lengths.extent(1); j++){
+      vdens.push_back(std::make_shared<ConstantDensity>(densities[i][j], 0.5));
+      vtrk.push_back(std::make_shared<ConstantDensity::Track>(lengths[i][j]));
+    }
+    const_dens_array.push_back(vdens);
+    const_dens_track_array.push_back(vtrk);
+  }
+  
+  marray<double,1> ini_state({3},{0,1,0});
+  // construct nusquids objects
+  for (int i = 0; i < lengths.extent(0); i++){
+    nusq_array.emplace_back(3, neutrino);
+    nusq_array.back().Set_E(10.*units.GeV);
+    // set body and track to the first layer of the array of layers 
+    // corresponding to this particular nusquids object.
+    nusq_array.back().Set_Body(const_dens_array[i][0]);
+    nusq_array.back().Set_Track(const_dens_track_array[i][0]);
+    nusq_array.back().Set_MixingParametersToDefault();
+    nusq_array.back().Set_AllowConstantDensityOscillationOnlyEvolution(true);
+    nusq_array.back().Set_initial_state(ini_state, flavor);
+  }
+
+  std::cout << "Ini state in nus objects:" << std::endl;
+  for (int n = 0; n < lengths.extent(0); n ++){
+    std::cout << n << ": ";
+    for(int i = 0; i < 3; i++){
+      std::cout << nusq_array[n].EvalFlavor(i) << " ";
+    }
+    std::cout << std::endl;
+  }
+
+  auto start = std::chrono::high_resolution_clock::now();
+  
+  if(evalThreads==1){
+    std::cout << "using single task mode" << std::endl;
+    for (int n = 0; n < lengths.extent(0); n++){
+      std::cout << "evolving nusq object " << n << std::endl;
+      for (int i = 0; i < lengths.extent(1); i++){
+        nusq_array[n].Set_Body(const_dens_array[n][i]);
+        nusq_array[n].Set_Track(const_dens_track_array[n][i]);
+        nusq_array[n].EvolveState();
+        //for(int j = 0; j < 3; j++){
+        //  std::cout << nusq_array[n].EvalFlavor(j) << " ";
+        //}
+        //std::cout << std::endl;
+      }
+    }
+  }
+  else{
+    std::cout << "using " << evalThreads << " threads" << std::endl;
+    for (int i = 0; i < lengths.extent(1); i++){
+      ThreadPool tpool(evalThreads);
+      std::vector<std::future<void>> tasks;
+      tasks.reserve(nusq_array.size());
+      std::cout << "working on layer " << i << std::endl;
+      for(int n = 0; n < nusq_array.size(); n++){
+        nusq_array[n].Set_Body(const_dens_array[n][i]);
+        nusq_array[n].Set_Track(const_dens_track_array[n][i]);
+      }
+      for(nuSQUIDS& nsq : nusq_array)
+         tasks.emplace_back(tpool.enqueue([&](){ nsq.EvolveState(); }));
+      for(const auto& task : tasks){
+        task.wait();
+      }
+    }
+    ////////////////////
+    // It would probably be more efficient if every thread could do the entire 
+    // evolution through all layers, rather than waiting for each layer to finish
+    // in all nuSQuIDS calculators. I was trying to do it below, but it doesn't work...
+    // If you have better C++ skills than me, you can probably make it work. 
+    //
+    // std::cout << "using " << evalThreads << " threads" << std::endl;
+    // ThreadPool tpool(evalThreads);
+    // std::vector<std::future<void>> tasks;
+    // tasks.reserve(nusq_array.size());
+    // 
+    // for(int n = 0; n < nusq_array.size(); n++){
+    //   nuSQUIDS& nus = nusq_array[n];
+    //   std::vector< std::shared_ptr<ConstantDensity>> vdens = const_dens_array[n];
+    //   std::vector< std::shared_ptr<ConstantDensity::Track>> vtrk = const_dens_track_array[n];
+    //   
+    //   tasks.emplace_back(tpool.enqueue([&](){
+    //     for (int i = 0; i < vdens.size(); i++){
+    //       nus.Set_Body(vdens[i]);
+    //       nus.Set_Track(vtrk[i]);
+    //       nus.EvolveState();
+    //     }
+    //   }));
+    // }
+    // for(const auto& task : tasks){
+    //   task.wait();
+    // }
+    ///////////////////
+  }
+
+  auto finish = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> elapsed = finish - start;
+  std::cout << "evolution time: " << elapsed.count() << " s" << std::endl;
+  
+  std::cout << "Final state in nus objects:" << std::endl;
+  for (int n = 0; n < lengths.extent(0); n ++){
+    std::cout << n << ": ";
+    for(int i = 0; i < 3; i++){
+      std::cout << nusq_array[n].EvalFlavor(i) << " ";
+    }
+    std::cout << std::endl;
+  }
+
+  return 0;
+}

--- a/examples/explicit_layers/main.cpp
+++ b/examples/explicit_layers/main.cpp
@@ -85,5 +85,25 @@ int main(){
     }
     std::cout << std::endl;
   }
+  
+  // The following demonstrates evaluation with a given interaction picture state.
+  // We just use the states as they are computed at the nodes, but in real life we
+  // would do some sort of interpolation externally.
+  std::cout << "Evaluating with states:" << std::endl;
+  marray<double,1> summed_lengths = lengths.sum(1);
+  
+  for (int n = 0; n < lengths.extent(0); n ++){
+    std::cout << n << ": ";
+    for(int i = 0; i < 3; i++){
+      // Is there no way to convert the slice more easily?
+      marray<double,1> state {states.extent(1)};
+      for (int j=0; j<state.extent(0); j++)
+        state[j] = states[n][j];
+      std::cout << nus_layer.EvalWithState(
+        i, summed_lengths[n], 10.*units.GeV, state
+      ) << " ";
+    }
+    std::cout << std::endl;
+  }
   return 0;
 }

--- a/include/nuSQuIDS/nuSQuIDS.h
+++ b/include/nuSQuIDS/nuSQuIDS.h
@@ -1929,6 +1929,8 @@ class nuSQUIDSLayers {
   
       // construct nusquids objects
       for (int i = 0; i < length_arr.extent(0); i++){
+        // TODO Currently, there is no constructor for single energy mode with 
+        // interactions, so `iinteraction` won't work.
         nusq_array.emplace_back(args...);
         nusq_array.back().Set_E(en_arr[i]);
         // Set body and track to the first layer of the array of layers 
@@ -2017,11 +2019,13 @@ class nuSQUIDSLayers {
         throw std::runtime_error("nuSQUIDSLayers::Error::First dimension of input must equal number of nodes.");
       unsigned int i = 0;
       for(BaseSQUIDS& nsq : nusq_array){
-        //marray<double,1> state{ini_flux.extent(2)};
-        //for(size_t j=0; j<ini_flux.extent(2); j++)
-        //  slice[j]=ini_flux[i][j];
-        //nsq.Set_initial_state(slice,basis);
-        nsq.Set_initial_state(ini_flux[i++],basis);
+        // marrays don't do this conversion for you, you can't just pass 
+        // ini_flux[i] as a state argument.
+        marray<double,1> slice{ini_flux.extent(2)};
+        for(size_t j=0; j<ini_flux.extent(2); j++)
+          slice[j]=ini_flux[i][j];
+        nsq.Set_initial_state(slice,basis);
+        i++;
       }
       iinistate = true;
     }

--- a/include/nuSQuIDS/nuSQuIDS.h
+++ b/include/nuSQuIDS/nuSQuIDS.h
@@ -2049,9 +2049,9 @@ class nuSQUIDSLayers {
       }
 
       if(evalThreads==1){
-        std::cout << "using single task mode" << std::endl;
+        //std::cout << "using single task mode" << std::endl;
         for (int n = 0; n < length_arr.extent(0); n++){
-          std::cout << "evolving nusq object " << n << std::endl;
+          //std::cout << "evolving nusq object " << n << std::endl;
           for (int i = 0; i < length_arr.extent(1); i++){
             nusq_array[n].Set_Body(const_dens_array[n][i]);
             nusq_array[n].Set_Track(const_dens_track_array[n][i]);
@@ -2060,12 +2060,12 @@ class nuSQUIDSLayers {
         }
       }
       else{
-        std::cout << "using " << evalThreads << " threads" << std::endl;
+        //std::cout << "using " << evalThreads << " threads" << std::endl;
         for (int i = 0; i < length_arr.extent(1); i++){
           ThreadPool tpool(evalThreads);
           std::vector<std::future<void>> tasks;
           tasks.reserve(nusq_array.size());
-          std::cout << "working on layer " << i << std::endl;
+          //std::cout << "working on layer " << i << std::endl;
           for(int n = 0; n < nusq_array.size(); n++){
             nusq_array[n].Set_Body(const_dens_array[n][i]);
             nusq_array[n].Set_Track(const_dens_track_array[n][i]);

--- a/resources/python/src/nuSQUIDSpy.cpp
+++ b/resources/python/src/nuSQUIDSpy.cpp
@@ -177,6 +177,8 @@ BOOST_PYTHON_MODULE(nuSQUIDSpy)
   ;
 
   class_<squids::Const, boost::noncopyable>("Const")
+    .def_readonly("GF",&squids::Const::GF)
+    .def_readonly("Na",&squids::Const::Na)
     .def_readonly("PeV",&squids::Const::PeV)
     .def_readonly("TeV",&squids::Const::TeV)
     .def_readonly("GeV",&squids::Const::GeV)

--- a/resources/python/src/nuSQUIDSpy.cpp
+++ b/resources/python/src/nuSQUIDSpy.cpp
@@ -136,6 +136,7 @@ BOOST_PYTHON_MODULE(nuSQUIDSpy)
 
   RegisterBasicNuSQuIDSPythonBindings<nuSQUIDS>("nuSQUIDS");
   RegisterBasicAtmNuSQuIDSPythonBindings<nuSQUIDS>("nuSQUIDSAtm");
+  RegisterBasicLayerNuSQuIDSPythonBindings<nuSQUIDS>("nuSQUIDSLayers");
 
   class_<NeutrinoCrossSections, std::shared_ptr<NeutrinoCrossSections>, boost::noncopyable >("NeutrinoCrossSections", no_init);
 

--- a/resources/python/src/nuSQUIDSpy.h
+++ b/resources/python/src/nuSQUIDSpy.h
@@ -244,6 +244,30 @@ static void wrap_nusqatm_Set_GSL_STEP(nuSQUIDSAtm<BaseType>* nusq, GSL_STEP_FUNC
   }
 }
 
+template<typename BaseType, typename = typename std::enable_if<std::is_base_of<nuSQUIDS,BaseType>::value>::type >
+static void wrap_nusqlayer_Set_GSL_STEP(nuSQUIDSLayers<BaseType>* nusq, GSL_STEP_FUNCTIONS step_enum){
+  switch(step_enum){
+    case GSL_STEP_RK2:
+      nusq->Set_GSL_step(gsl_odeiv2_step_rk2);
+      break;
+    case GSL_STEP_RK4:
+      nusq->Set_GSL_step(gsl_odeiv2_step_rk4);
+      break;
+    case GSL_STEP_RKF45:
+      nusq->Set_GSL_step(gsl_odeiv2_step_rkf45);
+      break;
+    case GSL_STEP_RKCK:
+      nusq->Set_GSL_step(gsl_odeiv2_step_rkck);
+      break;
+    case GSL_STEP_RK8PD:
+      nusq->Set_GSL_step(gsl_odeiv2_step_rk8pd);
+      break;
+    case GSL_STEP_MSADAMS:
+      nusq->Set_GSL_step(gsl_odeiv2_step_msadams);
+      break;
+  }
+}
+
 // overloaded function macro template creator //
 #define MAKE_OVERLOAD_TEMPLATE(name, fname, min_args, max_args) \
 template<typename T> \
@@ -419,4 +443,68 @@ template<typename BaseType, typename = typename std::enable_if<std::is_base_of<n
     }
 };
 
+MAKE_OVERLOAD_TEMPLATE(nuSQUIDSLayers_Set_initial_state,Set_initial_state,1,2)
+
+// registration for explicit layers template
+template<typename BaseType, typename = typename std::enable_if<std::is_base_of<nuSQUIDS,BaseType>::value>::type >
+  struct RegisterBasicLayerNuSQuIDSPythonBindings {
+    const std::string class_label;
+    std::shared_ptr<class_<nuSQUIDSLayers<BaseType>, boost::noncopyable, std::shared_ptr<nuSQUIDSLayers<BaseType>>>> class_object;
+    RegisterBasicLayerNuSQuIDSPythonBindings(std::string class_label){
+      class_object = std::make_shared<class_<nuSQUIDSLayers<BaseType>, boost::noncopyable, std::shared_ptr<nuSQUIDSLayers<BaseType>>>>(class_label.c_str(), no_init);
+
+      class_object->def(init<marray<double,2>,marray<double,2>,marray<double,2>,marray<double,1>,unsigned int,NeutrinoType>(args("lengths", "densities", "ye", "energies","numneu","NT")));
+      
+      //class_object->def(init<marray<double,2>,marray<double,2>,marray<double,2>,marray<double,1>,unsigned int,NeutrinoType,bool>(args("lengths", "densities", "ye", "energies","numneu","NT","iinteraction")));
+      //class_object->def(init<marray<double,2>,marray<double,2>,marray<double,2>,marray<double,1>,unsigned int,NeutrinoType,bool,std::shared_ptr<NeutrinoCrossSections>>(args("lengths", "densities", "ye", "energies","numneu","NT","iinteraction","ncs")));
+      //class_object->def(init<std::string>(args("filename")));
+      class_object->def("EvolveState",&nuSQUIDSLayers<BaseType>::EvolveState);
+      class_object->def("Set_TauRegeneration",&nuSQUIDSLayers<BaseType>::Set_TauRegeneration);
+      class_object->def("EvalFlavorAtNode",&nuSQUIDSLayers<BaseType>::EvalFlavorAtNode);
+      class_object->def("EvalWithState",&nuSQUIDSLayers<BaseType>::EvalWithState);
+      class_object->def("Set_EvalThreads",&nuSQUIDSLayers<BaseType>::Set_EvalThreads);
+      class_object->def("Get_EvalThreads",&nuSQUIDSLayers<BaseType>::Get_EvalThreads);
+      // class_object->def("WriteStateHDF5",&nuSQUIDSLayers<BaseType>::WriteStateHDF5);
+      // class_object->def("ReadStateHDF5",&nuSQUIDSLayers<BaseType>::ReadStateHDF5);
+      class_object->def("Set_MixingAngle",&nuSQUIDSLayers<BaseType>::Set_MixingAngle);
+      class_object->def("Get_MixingAngle",&nuSQUIDSLayers<BaseType>::Get_MixingAngle);
+      class_object->def("Set_CPPhase",&nuSQUIDSLayers<BaseType>::Set_CPPhase);
+      class_object->def("Get_CPPhase",&nuSQUIDSLayers<BaseType>::Get_CPPhase);
+      class_object->def("Set_SquareMassDifference",&nuSQUIDSLayers<BaseType>::Set_SquareMassDifference);
+      class_object->def("Get_SquareMassDifference",&nuSQUIDSLayers<BaseType>::Get_SquareMassDifference);
+      class_object->def("Set_h",(void(nuSQUIDSLayers<BaseType>::*)(double))&nuSQUIDSLayers<BaseType>::Set_h);
+      class_object->def("Set_h",(void(nuSQUIDSLayers<BaseType>::*)(double,unsigned int))&nuSQUIDSLayers<BaseType>::Set_h);
+      class_object->def("Set_h_max",(void(nuSQUIDSLayers<BaseType>::*)(double))&nuSQUIDSLayers<BaseType>::Set_h_max);
+      class_object->def("Set_h_max",(void(nuSQUIDSLayers<BaseType>::*)(double,unsigned int))&nuSQUIDSLayers<BaseType>::Set_h_max);
+      class_object->def("Set_h_min",(void(nuSQUIDSLayers<BaseType>::*)(double))&nuSQUIDSLayers<BaseType>::Set_h_min);
+      class_object->def("Set_h_min",(void(nuSQUIDSLayers<BaseType>::*)(double,unsigned int))&nuSQUIDSLayers<BaseType>::Set_h_min);
+      //class_object->def("Set_ProgressBar",&nuSQUIDSLayers<BaseType>::Set_ProgressBar);
+      class_object->def("Set_MixingParametersToDefault",&nuSQUIDSLayers<BaseType>::Set_MixingParametersToDefault);
+      class_object->def("Set_GSL_step",wrap_nusqlayer_Set_GSL_STEP<BaseType>);
+      class_object->def("Set_rel_error",(void(nuSQUIDSLayers<BaseType>::*)(double))&nuSQUIDSLayers<BaseType>::Set_rel_error);
+      class_object->def("Set_rel_error",(void(nuSQUIDSLayers<BaseType>::*)(double, unsigned int))&nuSQUIDSLayers<BaseType>::Set_rel_error);
+      class_object->def("Set_abs_error",(void(nuSQUIDSLayers<BaseType>::*)(double))&nuSQUIDSLayers<BaseType>::Set_abs_error);
+      class_object->def("Set_abs_error",(void(nuSQUIDSLayers<BaseType>::*)(double, unsigned int))&nuSQUIDSLayers<BaseType>::Set_abs_error);
+      class_object->def("GetNumNeu",&nuSQUIDSLayers<BaseType>::GetNumNeu);
+      class_object->def("GetNumRho",&nuSQUIDSLayers<BaseType>::GetNumRho);
+      class_object->def("GetnuSQuIDS",(std::vector<BaseType>&(nuSQUIDSLayers<BaseType>::*)())&nuSQUIDSLayers<BaseType>::GetnuSQuIDS,boost::python::return_internal_reference<>());
+      class_object->def("GetnuSQuIDS",(BaseType&(nuSQUIDSLayers<BaseType>::*)(unsigned int))&nuSQUIDSLayers<BaseType>::GetnuSQuIDS,boost::python::return_internal_reference<>());
+      // TODO Do we want to handle neutrinos and antineutrinos at the same time?
+      class_object->def("Set_initial_state",(void(nuSQUIDSLayers<BaseType>::*)(const marray<double,1>&, Basis))&nuSQUIDSLayers<BaseType>::Set_initial_state,nuSQUIDSLayers_Set_initial_state<nuSQUIDSLayers<BaseType>>());
+      class_object->def("Set_initial_state",(void(nuSQUIDSLayers<BaseType>::*)(const marray<double,2>&, Basis))&nuSQUIDSLayers<BaseType>::Set_initial_state,nuSQUIDSLayers_Set_initial_state<nuSQUIDSLayers<BaseType>>());
+      class_object->def("Set_IncludeOscillations",&nuSQUIDSLayers<BaseType>::Set_IncludeOscillations);
+      class_object->def("Set_GlashowResonance",&nuSQUIDSLayers<BaseType>::Set_GlashowResonance);
+      class_object->def("Set_TauRegeneration",&nuSQUIDSLayers<BaseType>::Set_TauRegeneration);
+      class_object->def("Set_AllowConstantDensityOscillationOnlyEvolution",&nuSQUIDSLayers<BaseType>::Set_AllowConstantDensityOscillationOnlyEvolution);
+      class_object->def("Set_PositivyConstrain",&nuSQUIDSLayers<BaseType>::Set_PositivityConstrain);
+      class_object->def("Set_PositivyConstrainStep",&nuSQUIDSLayers<BaseType>::Set_PositivityConstrainStep);
+      class_object->def("Get_EvalThreads",&nuSQUIDSLayers<BaseType>::Get_EvalThreads);
+      class_object->def("Set_EvalThreads",&nuSQUIDSLayers<BaseType>::Set_EvalThreads);
+      class_object->def("SetNeutrinoCrossSections",&nuSQUIDSLayers<BaseType>::SetNeutrinoCrossSections);
+      class_object->def("GetNeutrinoCrossSections",&nuSQUIDSLayers<BaseType>::GetNeutrinoCrossSections);
+    }
+    std::shared_ptr<class_<nuSQUIDSLayers<BaseType>, boost::noncopyable, std::shared_ptr<nuSQUIDSLayers<BaseType>>>> GetClassObject() {
+      return class_object;
+    }
+};
 #endif

--- a/resources/python/src/nuSQUIDSpy.h
+++ b/resources/python/src/nuSQUIDSpy.h
@@ -461,6 +461,7 @@ template<typename BaseType, typename = typename std::enable_if<std::is_base_of<n
       class_object->def("EvolveState",&nuSQUIDSLayers<BaseType>::EvolveState);
       class_object->def("Set_TauRegeneration",&nuSQUIDSLayers<BaseType>::Set_TauRegeneration);
       class_object->def("EvalFlavorAtNode",&nuSQUIDSLayers<BaseType>::EvalFlavorAtNode);
+      class_object->def("GetStates",&nuSQUIDSLayers<BaseType>::GetStatesArr);
       class_object->def("EvalWithState",&nuSQUIDSLayers<BaseType>::EvalWithState);
       class_object->def("Set_EvalThreads",&nuSQUIDSLayers<BaseType>::Set_EvalThreads);
       class_object->def("Get_EvalThreads",&nuSQUIDSLayers<BaseType>::Get_EvalThreads);

--- a/src/nuSQuIDS.cpp
+++ b/src/nuSQuIDS.cpp
@@ -125,7 +125,7 @@ void nuSQUIDS::init(double xini){
 
 void nuSQUIDS::Set_E(double Enu){
   if( ne != 1 )
-    throw std::runtime_error("nuSQUIDS::Error:Cannot use Set_E in single energy mode.");
+    throw std::runtime_error("nuSQUIDS::Error:Can only use Set_E in single energy mode.");
   E_range = marray<double,1>{1};
   E_range[0] = Enu;
   Set_xrange(std::vector<double>{Enu});


### PR DESCRIPTION
For my upcoming light sterile analysis at low energies, there are a number of technical challenges for which I needed more low-level control over nuSQuIDS accessible from Python. The new class `nuSQUIDSLayers` is not terribly useful on its own as it is intended to be used as a backend for a Python implementation in PISA (https://github.com/IceCubeOpenSource/pisa). Since this code is going to be used not only for me but by anyone using nuSQuIDS in PISA, I'd like to make this a PR into the main branch of nuSQuIDS and would kindly ask the maintainers to review the implementation. I'm not very familiar with C++ and there are a number of points where things could probably be solved more efficiently and/or nicely by someone with more skill than me...

The requirements I'm attempting to fulfill are:

- reproducibility of other PISA tools: In PISA, we have a common module to calculate the distances and densities through the Earth's layers. The class `nuSQUIDSLayers` is initialized with those pre-computed layers and the results can be directly compared to those of other tools already implemented (prob3, GLoBES).

- externalized state interpolation: By default, nuSQuIDS uses linear interpolation on the interaction picture states. I wanted to experiment with other interpolation methods and the best way to do that is to simply provide Pybindings to pass an interpolated state. For that, I implemented `EvalWithState`, which takes in the components of the interpolated state as a numpy array

- averaging of fast oscillations: I will need the ability to smooth the extremely fast oscillations coming from light steriles at energies below 100 GeV, and that again needs to be accessible from Python. Ideally, I would also like the ability to use the approximation in the RHS of the differential equations.