### PR TITLE
decrease reference count to converted numpy array to avoid memory leaks

### DIFF
--- a/resources/python/src/nuSQUIDSpy.h
+++ b/resources/python/src/nuSQUIDSpy.h
@@ -100,9 +100,12 @@ struct marray_from_python{
     PyArrayObject* numpy_array=PyArray_GETCONTIGUOUS((PyArrayObject*)obj_ptr);
     unsigned int array_dim = PyArray_NDIM(numpy_array);
     //require matching dimensions
-    if(array_dim!=Dim)
+    if(array_dim!=Dim){
+      Py_XDECREF(numpy_array);
       return(NULL);
+    }
     NPY_TYPES type = (NPY_TYPES) PyArray_DESCR(numpy_array)->type_num;
+    Py_XDECREF(numpy_array);
     //require a sane type
     switch(type){
       case NPY_BOOL:
@@ -120,8 +123,6 @@ struct marray_from_python{
       default:
         return(NULL);
     }
-    // Decreasing reference count
-    Py_XDECREF(numpy_array);
     return(obj_ptr);
   }
 

--- a/resources/python/src/nuSQUIDSpy.h
+++ b/resources/python/src/nuSQUIDSpy.h
@@ -92,6 +92,11 @@ struct marray_from_python{
     //accept only numpy arrays
     if(!PyArray_Check(obj_ptr))
       return(NULL);
+    // Analogously to what is described in
+    // https://docs.python.org/3/c-api/intro.html#reference-counts,
+    // the call below always increases the reference count of the object by one and we 
+    // are left with the responsibility to decrease the reference count when we are done
+    // with it.
     PyArrayObject* numpy_array=PyArray_GETCONTIGUOUS((PyArrayObject*)obj_ptr);
     unsigned int array_dim = PyArray_NDIM(numpy_array);
     //require matching dimensions
@@ -115,7 +120,8 @@ struct marray_from_python{
       default:
         return(NULL);
     }
-
+    // Decreasing reference count
+    Py_XDECREF(numpy_array);
     return(obj_ptr);
   }
 
@@ -184,6 +190,7 @@ struct marray_from_python{
       }
     } while(iternext(iter));
     NpyIter_Deallocate(iter);
+    Py_XDECREF(numpy_array);
   }
 };
 


### PR DESCRIPTION
Every time a numpy array was converted into an `marray`, its reference count increased by two, causing a memory leak. I found that this was caused by the two calls to `PyArray_GETCONTIGUOUS`, which each increase the reference count per convention by one and leave it to the caller to decrease it again when they are done with the object.