### PR TITLE
implement low-pass filter for RHS of state evolution

### DIFF
--- a/resources/python/src/nuSQUIDSpy.cpp
+++ b/resources/python/src/nuSQUIDSpy.cpp
@@ -177,6 +177,7 @@ BOOST_PYTHON_MODULE(nuSQUIDSpy)
   ;
 
   class_<squids::Const, boost::noncopyable>("Const")
+    .def_readonly("GF",&squids::Const::GF)
     .def_readonly("PeV",&squids::Const::PeV)
     .def_readonly("TeV",&squids::Const::TeV)
     .def_readonly("GeV",&squids::Const::GeV)

--- a/resources/python/src/nuSQUIDSpy.h
+++ b/resources/python/src/nuSQUIDSpy.h
@@ -311,6 +311,8 @@ template<typename BaseType, typename = typename std::enable_if<std::is_base_of<n
       class_object->def("GetHamiltonian",&BaseType::GetHamiltonian);
       class_object->def("GetState",(const squids::SU_vector&(BaseType::*)(unsigned int))&BaseType::GetState, return_value_policy<copy_const_reference>());
       class_object->def("GetState",(const squids::SU_vector&(BaseType::*)(unsigned int, unsigned int))&BaseType::GetState, return_value_policy<copy_const_reference>());
+      class_object->def("Set_EvolLowPassCutoff", &BaseType::Set_EvolLowPassCutoff);
+      class_object->def("Set_EvolLowPassScale", &BaseType::Set_EvolLowPassScale);
       class_object->def("Set_h_min",&BaseType::Set_h_min);
       class_object->def("Set_h_max",&BaseType::Set_h_max);
       class_object->def("Set_h",&BaseType::Set_h);
@@ -358,6 +360,7 @@ template<typename BaseType, typename = typename std::enable_if<std::is_base_of<n
 // nuSQUIDSAtm-like overloads factories
 MAKE_OVERLOAD_TEMPLATE(nuSQUIDSAtm_EvalFlavor_overload,EvalFlavor,3,5)
 MAKE_OVERLOAD_TEMPLATE(nuSQUIDSAtm_Set_initial_state,Set_initial_state,1,2)
+MAKE_OVERLOAD_TEMPLATE(nuSQUIDSAtm_GetStates_overload, GetStates, 0, 1)
 
 // registration for atmospheric template
 template<typename BaseType, typename = typename std::enable_if<std::is_base_of<nuSQUIDS,BaseType>::value>::type >
@@ -400,6 +403,8 @@ template<typename BaseType, typename = typename std::enable_if<std::is_base_of<n
       class_object->def("Set_rel_error",(void(nuSQUIDSAtm<BaseType>::*)(double, unsigned int))&nuSQUIDSAtm<BaseType>::Set_rel_error);
       class_object->def("Set_abs_error",(void(nuSQUIDSAtm<BaseType>::*)(double))&nuSQUIDSAtm<BaseType>::Set_abs_error);
       class_object->def("Set_abs_error",(void(nuSQUIDSAtm<BaseType>::*)(double, unsigned int))&nuSQUIDSAtm<BaseType>::Set_abs_error);
+      class_object->def("Set_EvolLowPassCutoff",&nuSQUIDSAtm<BaseType>::Set_EvolLowPassCutoff);
+      class_object->def("Set_EvolLowPassScale",&nuSQUIDSAtm<BaseType>::Set_EvolLowPassScale);
       class_object->def("GetNumE",&nuSQUIDSAtm<BaseType>::GetNumE);
       class_object->def("GetNumCos",&nuSQUIDSAtm<BaseType>::GetNumCos);
       class_object->def("GetNumNeu",&nuSQUIDSAtm<BaseType>::GetNumNeu);
@@ -408,6 +413,8 @@ template<typename BaseType, typename = typename std::enable_if<std::is_base_of<n
       class_object->def("GetnuSQuIDS",(BaseType&(nuSQUIDSAtm<BaseType>::*)(unsigned int))&nuSQUIDSAtm<BaseType>::GetnuSQuIDS,boost::python::return_internal_reference<>());
       class_object->def("Set_initial_state",(void(nuSQUIDSAtm<BaseType>::*)(const marray<double,3>&, Basis))&nuSQUIDSAtm<BaseType>::Set_initial_state,nuSQUIDSAtm_Set_initial_state<nuSQUIDSAtm<BaseType>>());
       class_object->def("Set_initial_state",(void(nuSQUIDSAtm<BaseType>::*)(const marray<double,4>&, Basis))&nuSQUIDSAtm<BaseType>::Set_initial_state,nuSQUIDSAtm_Set_initial_state<nuSQUIDSAtm<BaseType>>());
+      class_object->def("GetStates", (marray<double,2>(nuSQUIDSAtm<BaseType>::*)(unsigned int))&nuSQUIDSAtm<BaseType>::GetStates,
+        nuSQUIDSAtm_GetStates_overload<nuSQUIDSAtm<BaseType>>(args("rho"), "Get evolved states of all nodes"));
       class_object->def("GetERange",&nuSQUIDSAtm<BaseType>::GetERange);
       class_object->def("GetCosthRange",&nuSQUIDSAtm<BaseType>::GetCosthRange);
       class_object->def("Set_IncludeOscillations",&nuSQUIDSAtm<BaseType>::Set_IncludeOscillations);

--- a/src/nuSQuIDS.cpp
+++ b/src/nuSQuIDS.cpp
@@ -280,6 +280,19 @@ void nuSQUIDS::EvolveProjectors(double x){
   std::unique_ptr<double[]> evol_buf(new double[H0_array[0].GetEvolveBufferSize()]);
   for(unsigned int ei = 0; ei < ne; ei++){
     H0_array[ei].PrepareEvolve(evol_buf.get(),x-Get_t_initial());
+    if (evol_lowpass_cutoff > 0){
+      // std::cout << "evol_buf: ";
+      // for (unsigned int i = 0; i < H0_array[ei].GetEvolveBufferSize(); i++){
+      //   std::cout << evol_buf.get()[i] << "  ";
+      // }
+      // std::cout << std::endl;
+      H0_array[ei].LowPassFilter(evol_buf.get(), evol_lowpass_cutoff, evol_lowpass_scale);
+      // std::cout << "evol_buf after filter: ";
+      // for (unsigned int i = 0; i < H0_array[ei].GetEvolveBufferSize(); i++){
+      //   std::cout << evol_buf.get()[i] << "  ";
+      // }
+      // std::cout << std::endl;
+    }
     for(unsigned int rho = 0; rho < nrhos; rho++){
       for(unsigned int flv = 0; flv < numneu; flv++){
         // will only evolve the flavor projectors
@@ -2386,7 +2399,13 @@ void nuSQUIDS::Set_ProgressBar(bool opt){
   progressbar = opt;
 }
 
+void nuSQUIDS::Set_EvolLowPassCutoff(double val){
+  evol_lowpass_cutoff = val;
+}
 
+void nuSQUIDS::Set_EvolLowPassScale(double val){
+  evol_lowpass_scale = val;
+}
 void nuSQUIDS::Set_IncludeOscillations(bool opt){
   ioscillations = opt;
 }


### PR DESCRIPTION
This PR adds only the newly implemented low-pass filter for the RHS of the interaction picture state evolution. This feature is added with Pybindings to both the base nuSQuIDS object as well as nuSQUIDSAtm, though I only tested it for the former. 
This filter can potentially greatly speed up the numerical integration by filtering out very high frequencies in the RHS that the integrator would otherwise have to keep track of with very tiny step sizes. For example, in the presence of a 1 eV sterile neutrino going straight up through the earth in an energy range between 2 and 200 GeV I find a speedup of nearly a factor of 10 as demonstrated in [this notebook](https://github.com/IceCubeOpenSource/fridge/blob/master/analysis/sandbox/atrettin/notebooks/nusquids%20deep%20dive.ipynb).
I also added a Pybinding to get the states from all nodes in nuSQUIDSAtm that can help debugging and optimizing node placement.