### PR TITLE
Fix de-normalization error in EarthAtm class

### DIFF
--- a/src/body.cpp
+++ b/src/body.cpp
@@ -812,7 +812,7 @@ double EarthAtm::density(const GenericTrack& track_input) const
   else if ( rel_r > x_radius_max and rel_r < radius/earth_with_atm_radius) {
     return x_rho_max;
   }
-  else if ( r > radius) {
+  else if ( rel_r > radius/earth_with_atm_radius) {
     double h = r - radius; // height above surface in km
     double h0 = 7.594; //km obtained by fitting the NRLMSISE atmospheric model up to 60 km to an exponetial profile
     // deviations from NRLMSISE model above this height can be subtantial.

--- a/src/body.cpp
+++ b/src/body.cpp
@@ -812,8 +812,8 @@ double EarthAtm::density(const GenericTrack& track_input) const
   else if ( rel_r > x_radius_max and rel_r < radius/earth_with_atm_radius) {
     return x_rho_max;
   }
-  else if ( rel_r > radius/earth_with_atm_radius ) {
-    double h = earth_with_atm_radius*(rel_r - radius/earth_with_atm_radius); // de-normalize to get height above surface in km
+  else if ( r > radius) {
+    double h = r - radius; // height above surface in km
     double h0 = 7.594; //km obtained by fitting the NRLMSISE atmospheric model up to 60 km to an exponetial profile
     // deviations from NRLMSISE model above this height can be subtantial.
     return 0.0012*exp(-h/h0); // use as constant the atmospheric density at surface in gr/cm^3

--- a/src/body.cpp
+++ b/src/body.cpp
@@ -809,16 +809,16 @@ double EarthAtm::density(const GenericTrack& track_input) const
   if ( rel_r < x_radius_min ){
     return x_rho_min;
   }
-  else if ( rel_r > x_radius_max and rel_r < radius/earth_with_atm_radius) {
+  else if ( rel_r > x_radius_max and r < radius) {
     return x_rho_max;
   }
-  else if ( rel_r > radius/earth_with_atm_radius) {
+  else if ( r > radius) {
     double h = r - radius; // height above surface in km
     double h0 = 7.594; //km obtained by fitting the NRLMSISE atmospheric model up to 60 km to an exponetial profile
     // deviations from NRLMSISE model above this height can be subtantial.
     return 0.0012*exp(-h/h0); // use as constant the atmospheric density at surface in gr/cm^3
   } else {
-    return inter_density(r/radius);
+    return inter_density(rel_r);
   }
 }
 
@@ -835,10 +835,10 @@ double EarthAtm::ye(const GenericTrack& track_input) const
   if ( rel_r < x_radius_min ){
     return x_ye_min;
   }
-  else if ( rel_r > x_radius_max and rel_r < radius/earth_with_atm_radius) {
+  else if ( rel_r > x_radius_max and r < radius) {
     return x_ye_max;
   }
-  else if ( rel_r > radius/earth_with_atm_radius ){
+  else if ( r > radius ){
     return 0.494;
   }else {
     return inter_ye(rel_r);

--- a/src/body.cpp
+++ b/src/body.cpp
@@ -813,7 +813,7 @@ double EarthAtm::density(const GenericTrack& track_input) const
     return x_rho_max;
   }
   else if ( rel_r > radius/earth_with_atm_radius ) {
-    double h = atm_height*(rel_r - radius/earth_with_atm_radius); // here atm_height is a member of EarthAtm in km
+    double h = earth_with_atm_radius*(rel_r - radius/earth_with_atm_radius); // de-normalize to get height above surface in km
     double h0 = 7.594; //km obtained by fitting the NRLMSISE atmospheric model up to 60 km to an exponetial profile
     // deviations from NRLMSISE model above this height can be subtantial.
     return 0.0012*exp(-h/h0); // use as constant the atmospheric density at surface in gr/cm^3


### PR DESCRIPTION
Fixes incorrect de-normalization of relative radius in order to correctly return the current height above the surface of Earth along the track.