### PR TITLE
Fixes for python detection:

### DIFF
--- a/configure
+++ b/configure
@@ -168,31 +168,24 @@ find_hdf5(){
 try_find_python(){
 	echo "Looking for python"
 
-	if which ${PYTHON_EXE} > /dev/null 2>&1; then
-		PYTHON_EXE=$(which ${PYTHON_EXE} 2>/dev/null)
+	if command -v "${PYTHON_EXE}" > /dev/null 2>&1; then
+		PYTHON_EXE=$(command -v ${PYTHON_EXE} 2>/dev/null)
 		echo " Using python executable ${PYTHON_EXE}"
 	else
 		echo " ${PYTHON_EXE} is not a valid python executable"
 		return
 	fi
 
-	PYTHON_VERSION=`${PYTHON_EXE} -c 'import sys; print(str(sys.version_info.major)+"."+str(sys.version_info.minor))'`
+	PYTHON_VERSION=$("${PYTHON_EXE}" -c 'import sys; print(str(sys.version_info.major)+"."+str(sys.version_info.minor))')
 	if [ "$?" -ne 0 ]; then
 		echo "Unable to use python executable ${PYTHON_EXE} (version check failed)"
 		return
 	fi
-	PYTHONVERSIONSIMPLE=`${PYTHON_EXE} -c 'import sys; print(str(sys.version_info.major)+str(sys.version_info.minor))'`
-	
-	PYTHON_INCDIR=`${PYTHON_EXE} -c 'from distutils import sysconfig; print(sysconfig.get_python_inc())'`
-	if [ -d "$PYTHON_INCDIR" ]; then
-		echo " Found python include dir $PYTHON_INCDIR"
-	else
-		echo " Unable to locate the python include dir"
-		return
-	fi
+	PYTHONVERSIONSIMPLE=$("${PYTHON_EXE}" -c 'import sys; print(str(sys.version_info.major)+str(sys.version_info.minor))')
 
 	# This is the directory to which libraries should be installed for python to find them
-	PYTHON_MODULEDIR=`${PYTHON_EXE} -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True, standard_lib=False))'`
+# 	PYTHON_MODULEDIR=`${PYTHON_EXE} -c 'import site; print(site.USER_SITE)'`
+	PYTHON_MODULEDIR=$("${PYTHON_EXE}" -c 'import sysconfig; print(sysconfig.get_path("platlib"))')
 	if [ "$PYTHON_MODULEDIR" ]; then
 		echo " Python module install dir is $PYTHON_MODULEDIR"
 	else
@@ -200,18 +193,34 @@ try_find_python(){
 		return
 	fi
 	
-	# This is the directory that python claims contains its standard library, 
-	# which may or may not include the actual libpython
-	PYTHON_STDLIBDIR=`${PYTHON_EXE} -c 'from distutils import sysconfig; print(sysconfig.get_python_lib(plat_specific=True,standard_lib=True))'`
 	# This may contain a suffix which appears after the version like in 'libpython3.6m'
 	# See https://www.python.org/dev/peps/pep-3149/#proposal
-	PYTHONLIBSUFFIX=`${PYTHON_EXE} -c 'from distutils import sysconfig; print(sysconfig.build_flags)' 2>/dev/null`
-
-	# Here we just try to guess every location anyone has ever seen a libpython in the wild
-	POSSIBLE_PYTHON_LIBDIRS="/lib /lib64 /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64 ${PYTHON_STDLIBDIR} ${PYTHON_STDLIBDIR}/lib"
-	# sometimes Apple puts a symlink in ${PYTHONSTDLIBDIR}/lib, sometimes it doesn't
-	TMP=`echo "$PYTHON_STDLIBDIR" | sed -n s'|\(.*/lib\)/python'"${PYTHON_VERSION}"'|\1|p'`
-	if [ "$TMP" ]; then POSSIBLE_PYTHON_LIBDIRS="${POSSIBLE_PYTHON_LIBDIRS} ${TMP}"; fi
+	PYTHONLIBSUFFIX=$("${PYTHON_EXE}" -c 'import sysconfig; print(sysconfig.get_config_var("ABIFLAGS") or "")')
+	
+	PYTHON_INCDIR=$("${PYTHON_EXE}" -c 'import sysconfig; print(sysconfig.get_path("include"))')
+	if [ -d "$PYTHON_INCDIR" -a -f "${PYTHON_INCDIR}/Python.h" ]; then
+		echo " Found python include dir $PYTHON_INCDIR"
+	else
+		# Sometimes (e.g. Apple dev tools pythons 3) sysconfig.get_path("include") is just a lie.
+		# If it didn't help try using basically the logic distutils.sysconfig used
+		PYTHON_INCDIR=$("${PYTHON_EXE}" -c 'import sys; print(sys.base_prefix)')"/include/python${PYTHON_VERSION}${PYTHONLIBSUFFIX}"
+		if [ -d "$PYTHON_INCDIR" -a -f "${PYTHON_INCDIR}/Python.h" ]; then
+			echo " Found python include dir $PYTHON_INCDIR"
+		else
+			echo " Unable to locate the python include dir"
+			return
+		fi
+	fi
+	
+	# This is the directory that python claims contains its standard library, 
+	# which may or may not include the actual libpython
+	PYTHON_STDLIBDIR=$("${PYTHON_EXE}" -c 'import sysconfig; print(sysconfig.get_path("platstdlib"))')
+	POSSIBLE_PYTHON_LIBDIRS="${PYTHON_STDLIBDIR} ${PYTHON_STDLIBDIR}/lib"
+	# Using venv makes sysconfig.get_path("platstdlib") point to a directory which often  does not
+	# contain the python library itself, so try off of the base prefix as well
+	POSSIBLE_PYTHON_LIBDIRS="$POSSIBLE_PYTHON_LIBDIRS "$("${PYTHON_EXE}" -c 'import sys; print(sys.base_prefix)')"/lib"
+	# or maybe the python library is just in a common system location?
+	POSSIBLE_PYTHON_LIBDIRS="${POSSIBLE_PYTHON_LIBDIRS} /lib /lib64 /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64"
 	# Ubuntu is special, of course
 	if [ $OS_DISTRIB = "Ubuntu" ]; then
 		POSSIBLE_PYTHON_LIBDIRS="${POSSIBLE_PYTHON_LIBDIRS} /usr/lib/$(uname -i)-linux-gnu"
@@ -233,6 +242,7 @@ try_find_python(){
 				fi
 			fi
 		done
+		if [ "$PYTHON_LIBRARY" ]; then break; fi
 	done
 	if [ -e "$PYTHON_LIBRARY" ]; then
 		echo " Found python library $PYTHON_LIBRARY"


### PR DESCRIPTION
Avoid depending on distutils, which is removed in python 3.12. Fixes https://github.com/arguelles/nuSQuIDS/issues/42 .

Tested with:
- Apple system python 2.7
- Apple dev tools python 3.7
- Apple dev tools python 3.8
- Python 3.12 built from source on Mac OS
- venv based on Apple dev tools python 3.7
- venv based on Apple dev tools python 3.8
- venv based on python 3.12 built from source on Mac OS
- Python 3.9 from DNF on Alma Linux 8.5
- venv based on python 3.9 from DNF on Alma Linux 8.5

Other tests which should be done:
- [ ] Homebrew python
- [ ] System python on a recent Ubuntu