### PR TITLE
Update python bindings install docs & fix typo in `SetAtmosphereHeight` binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,5 @@ If you have activated the python interface by doing `--with-python-bindings` the
 Even when configured the python interface is not built with the main library. 
 To compile it do the following:
 
-	cd resources/python/src/
-	make
-
-After successful compilation the bindings will be stored in `resources/python/bindings/`. 
-To make them available from within python, modify your PYTHONPATH:
-
-	export PYTHONPATH=$(PATH_TO_nuSQUIDS)/resources/python/bindings/:$PYTHONPATH
+	make python
+	make python-install

--- a/resources/python/src/nuSQUIDSpy.cpp
+++ b/resources/python/src/nuSQUIDSpy.cpp
@@ -376,7 +376,7 @@ BOOST_PYTHON_MODULE(nuSQuIDS)
     .def(init<std::string>())
     .def("GetRadius",&EarthAtm::GetRadius)
     .def("GetAtmosphereHeight",&EarthAtm::GetAtmosphereHeight)
-    .def("SetAtmosphereHeight",&EarthAtm::GetAtmosphereHeight)
+    .def("SetAtmosphereHeight",&EarthAtm::SetAtmosphereHeight)
     .def("MakeTrack",&EarthAtm::MakeTrack)
     .def("MakeTrackWithCosine",&EarthAtm::MakeTrackWithCosine)
     ;


### PR DESCRIPTION
I tried to install the python bindings according to the README.md but it did not work. In the end I checked the Makefile to see what install targets are available, and with `make python` and `make python-install` it worked. I updated the docs. I also fixed a typo in the python binding of `SetAtmosphereHeight`