### PR TITLE
move AddToReadHDF5() in ReadStateHDF5()

### DIFF
--- a/src/nuSQuIDS.cpp
+++ b/src/nuSQuIDS.cpp
@@ -2423,6 +2423,13 @@ void nuSQUIDS::ReadStateHDF5(std::string str,std::string grp,std::string cross_s
   // set time offset
   time_offset = squids_time - track->GetX();
 
+  // read from user parameters
+  hid_t user_parameters_id = H5Gopen(group, "user_parameters", H5P_DEFAULT);
+  //H5Eset_auto (H5E_DEFAULT,(H5E_auto_t) H5Eprint,stderr);
+  AddToReadHDF5(user_parameters_id);
+  //H5Eset_auto (H5E_DEFAULT,nullptr,nullptr);
+  H5Gclose(user_parameters_id);
+
   // reinitialize projectors
   iniProjectors();
   // reinitizize H0
@@ -2698,13 +2705,6 @@ void nuSQUIDS::ReadStateHDF5(std::string str,std::string grp,std::string cross_s
 
     interactions_initialized = true;
   }
-
-  // read from user parameters
-  hid_t user_parameters_id = H5Gopen(group, "user_parameters", H5P_DEFAULT);
-  //H5Eset_auto (H5E_DEFAULT,(H5E_auto_t) H5Eprint,stderr);
-  AddToReadHDF5(user_parameters_id);
-  //H5Eset_auto (H5E_DEFAULT,nullptr,nullptr);
-  H5Gclose(user_parameters_id);
 
   // we assume that this was created with the writer and got to this point!
   istate = true;


### PR DESCRIPTION
move AddToReadHDF5() in ReadStateHDF5() s.t. user_parameters are loaded before iniProjectors(). This is important for theories that override the iniProjectors() function.